### PR TITLE
Add session id to telemetry

### DIFF
--- a/src/MauiInsights.App/MauiProgram.cs
+++ b/src/MauiInsights.App/MauiProgram.cs
@@ -10,7 +10,7 @@ public static class MauiProgram
 		var builder = MauiApp.CreateBuilder();
 		builder
 			.UseMauiApp<TestApp>()
-			.AddApplicationInsights("<connection string>")
+			.AddApplicationInsights("InstrumentationKey=65926b9d-34fa-4f47-9474-9f6186ac623e;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/;ApplicationId=55c38abb-35b9-4952-9d8d-800b4f32dc3b")
 			.AddCrashLogging()
 			.ConfigureFonts(fonts =>
 			{

--- a/src/MauiInsights.Tests/CrashLoggerTests.cs
+++ b/src/MauiInsights.Tests/CrashLoggerTests.cs
@@ -16,8 +16,9 @@ namespace MauiInsights.Tests
             // Arrange
             var path = $"{Guid.NewGuid()}";
             Directory.CreateDirectory(path);
+            var sessionId = new SessionId();
             var message = "Cannot do this";
-            var logger = new CrashLogger(path);
+            var logger = new CrashLogger(new CrashLogSettings(path), sessionId);
 
             try
             {
@@ -31,6 +32,7 @@ namespace MauiInsights.Tests
                 log.Message.Should().Be(message);
                 log.ExceptionDetailsInfoList.Should().HaveCount(1);
                 log.ExceptionDetailsInfoList.First().TypeName.Should().Contain(nameof(InvalidOperationException));
+                log.Context.Session.Id.Should().Be(sessionId.Value);
             }
             finally
             {
@@ -45,7 +47,7 @@ namespace MauiInsights.Tests
             var path = $"{Guid.NewGuid()}";
             Directory.CreateDirectory(path);
             var message = "Cannot do this";
-            var logger = new CrashLogger(path);
+            var logger = new CrashLogger(new CrashLogSettings(path), new SessionId());
             logger.LogToFileSystem(new InvalidOperationException(message));
 
             // Act
@@ -60,7 +62,7 @@ namespace MauiInsights.Tests
         {
             var path = $"{Guid.NewGuid()}";
 
-            var act = () => new CrashLogger(path);
+            var act = () => new CrashLogger(new CrashLogSettings(path), new SessionId());
 
             act.Should().Throw<DirectoryNotFoundException>();
         }

--- a/src/MauiInsights/CrashHandling/CrashLogger.cs
+++ b/src/MauiInsights/CrashHandling/CrashLogger.cs
@@ -1,16 +1,21 @@
 ﻿using Microsoft.ApplicationInsights.DataContracts;
 using System.Text.Json;
+using Microsoft.ApplicationInsights;
 
 namespace MauiInsights.CrashHandling
 {
+    internal record CrashLogSettings(string Directory);
+    
     internal class CrashLogger
     {
+        private readonly TelemetryClient? _client;
         private const string CrashLogExtension = ".crashlog";
         private readonly string _crashlogDirectory;
-        public CrashLogger(string crashlogDirectory)
+        public CrashLogger(CrashLogSettings settings, TelemetryClient? client)
         {
-            EnsureCanWrite(crashlogDirectory);
-            _crashlogDirectory = crashlogDirectory;
+            _client = client;
+            EnsureCanWrite(settings.Directory);
+            _crashlogDirectory = settings.Directory;
         }
 
         private static void EnsureCanWrite(string crashlogDirectory)
@@ -26,15 +31,17 @@ namespace MauiInsights.CrashHandling
             {
                 var telemetry = new ExceptionTelemetry(e)
                 {
-                    Timestamp = DateTimeOffset.UtcNow
+                    Timestamp = DateTimeOffset.UtcNow,
                 };
-
+                telemetry.Context.Session.Id = _client?.Context.Session.Id;
+                
                 var path = Path.Combine(_crashlogDirectory, $"{Guid.NewGuid()}{CrashLogExtension}");
                 using var writer = new StreamWriter(File.OpenWrite(path));
                 var jsonWriter = new JsonSerializationWriter(writer);
                 jsonWriter.WriteStartObject();
                 telemetry.SerializeData(jsonWriter);
                 jsonWriter.WriteProperty(nameof(ExceptionInfo.timestamp), telemetry.Timestamp);
+                jsonWriter.WriteProperty(nameof(ExceptionInfo.sessionId), telemetry.Context.Session.Id);
                 jsonWriter.WriteEndObject();
             }
             catch
@@ -55,10 +62,12 @@ namespace MauiInsights.CrashHandling
                 {
                     continue;
                 }
-                yield return new ExceptionTelemetry(exceptionInfo.exceptions.Select(e => e.Map()), SeverityLevel.Error, "", new Dictionary<string, string>(), new Dictionary<string, double>())
+                var telemetry = new ExceptionTelemetry(exceptionInfo.exceptions.Select(e => e.Map()), SeverityLevel.Error, "", new Dictionary<string, string>(), new Dictionary<string, double>())
                 {
                     Timestamp = exceptionInfo.timestamp
                 };
+                telemetry.Context.Session.Id = exceptionInfo.sessionId;
+                yield return telemetry;
             }
         }
 

--- a/src/MauiInsights/CrashHandling/CrashLogger.cs
+++ b/src/MauiInsights/CrashHandling/CrashLogger.cs
@@ -8,12 +8,12 @@ namespace MauiInsights.CrashHandling
     
     internal class CrashLogger
     {
-        private readonly TelemetryClient? _client;
+        private readonly SessionId? _sessionId;
         private const string CrashLogExtension = ".crashlog";
         private readonly string _crashlogDirectory;
-        public CrashLogger(CrashLogSettings settings, TelemetryClient? client)
+        public CrashLogger(CrashLogSettings settings, SessionId? sessionId)
         {
-            _client = client;
+            _sessionId = sessionId;
             EnsureCanWrite(settings.Directory);
             _crashlogDirectory = settings.Directory;
         }
@@ -33,7 +33,7 @@ namespace MauiInsights.CrashHandling
                 {
                     Timestamp = DateTimeOffset.UtcNow,
                 };
-                telemetry.Context.Session.Id = _client?.Context.Session.Id;
+                telemetry.Context.Session.Id = _sessionId?.Value;
                 
                 var path = Path.Combine(_crashlogDirectory, $"{Guid.NewGuid()}{CrashLogExtension}");
                 using var writer = new StreamWriter(File.OpenWrite(path));

--- a/src/MauiInsights/CrashHandling/ExceptionInfo.cs
+++ b/src/MauiInsights/CrashHandling/ExceptionInfo.cs
@@ -2,7 +2,7 @@
 
 namespace MauiInsights.CrashHandling
 {
-    internal record ExceptionInfo(int ver, List<ExceptionData> exceptions, DateTimeOffset timestamp);
+    internal record ExceptionInfo(int ver, List<ExceptionData> exceptions, DateTimeOffset timestamp, string sessionId);
 
     internal record ExceptionData(int id, int outerId, string typeName, string message, bool hasFullStack, List<StackTracePart>? parsedStack)
     {

--- a/src/MauiInsights/DependencyTrackingHandler.cs
+++ b/src/MauiInsights/DependencyTrackingHandler.cs
@@ -31,13 +31,14 @@ namespace MauiInsights
             }
         }
 
-        private static DependencyTelemetry GetTelemetry(HttpRequestMessage request)
+        private DependencyTelemetry GetTelemetry(HttpRequestMessage request)
         {
             var host = request.RequestUri?.Host ?? "Unknown url";
             var call = request.RequestUri?.AbsolutePath ?? "Unknown url";
             var operationId = Guid.NewGuid().ToString().Replace("-", "");
             var telemetry = new DependencyTelemetry("Http", host, call, "");
             telemetry.Context.Operation.Id = operationId;
+            telemetry.Context.Session.Id = _client.Context.Session.Id;
             return telemetry;
         }
 

--- a/src/MauiInsights/MauiAppBuilderExtensions.cs
+++ b/src/MauiInsights/MauiAppBuilderExtensions.cs
@@ -62,7 +62,7 @@ public static class MauiAppBuilderExtensions
 
     public static MauiAppBuilder AddCrashLogging(this MauiAppBuilder appBuilder, IConnectivity connectivity, string crashlogDirectory)
     {
-        var crashLogger = new CrashLogger(new CrashLogSettings(crashlogDirectory), _client);
+        var crashLogger = new CrashLogger(new CrashLogSettings(crashlogDirectory), _sessionId);
         appBuilder.Services.AddSingleton(crashLogger);
         AppDomain.CurrentDomain.UnhandledException += (sender, e) => crashLogger.LogToFileSystem(e.ExceptionObject as Exception);
         TaskScheduler.UnobservedTaskException += (sender, e) => crashLogger.LogToFileSystem(e.Exception);

--- a/src/MauiInsights/MauiAppBuilderExtensions.cs
+++ b/src/MauiInsights/MauiAppBuilderExtensions.cs
@@ -14,6 +14,7 @@ namespace MauiInsights;
 public static class MauiAppBuilderExtensions
 {
     private static TelemetryClient? _client;
+    private static SessionId? _sessionId;
     public static MauiAppBuilder AddApplicationInsights(this MauiAppBuilder appBuilder, string appInsightsConnectionString, Action<TelemetryConfiguration>? configureTelemetry = null) => AddApplicationInsights(appBuilder, new MauiInsightsConfiguration { ApplicationInsightsConnectionString = appInsightsConnectionString }, configureTelemetry);
 
     public static MauiAppBuilder AddApplicationInsights(this MauiAppBuilder appBuilder, MauiInsightsConfiguration configuration, Action<TelemetryConfiguration>? configureTelemetry = null)
@@ -23,7 +24,8 @@ public static class MauiAppBuilderExtensions
             throw new ArgumentException("Configuration must have a valid Application Insights Connection string", nameof(configuration));
         }
         configureTelemetry ??= _ => { };
-        
+        _sessionId = new SessionId();
+        appBuilder.Services.AddSingleton(_sessionId);
         SetupTelemetryClient(appBuilder, configuration, configureTelemetry);
         SetupHttpDependecyTracking(appBuilder);
         SetupPageViewTelemetry();
@@ -60,11 +62,11 @@ public static class MauiAppBuilderExtensions
 
     public static MauiAppBuilder AddCrashLogging(this MauiAppBuilder appBuilder, IConnectivity connectivity, string crashlogDirectory)
     {
-        var crashLogger = new CrashLogger(crashlogDirectory);
+        var crashLogger = new CrashLogger(new CrashLogSettings(crashlogDirectory), _client);
         appBuilder.Services.AddSingleton(crashLogger);
         AppDomain.CurrentDomain.UnhandledException += (sender, e) => crashLogger.LogToFileSystem(e.ExceptionObject as Exception);
         TaskScheduler.UnobservedTaskException += (sender, e) => crashLogger.LogToFileSystem(e.Exception);
-
+        
         SetupCrashlogLifecycleEvents(appBuilder, connectivity, crashLogger);
         return appBuilder;
     }
@@ -114,6 +116,7 @@ public static class MauiAppBuilderExtensions
         var telemetryConfiguration = GetTelemetryConfiguration(appBuilder, configuration);
         configureTelemetry(telemetryConfiguration);
         _client = new TelemetryClient(telemetryConfiguration);
+        _client.Context.Session.Id = _sessionId?.Value;
         appBuilder.Services.AddSingleton(_client);
     }
 
@@ -140,8 +143,9 @@ public static class MauiAppBuilderExtensions
         var logConfig = new ApplicationInsightsLoggerOptions()
         {
             FlushOnDispose = true,
-            TrackExceptionsAsExceptionTelemetry = true
+            TrackExceptionsAsExceptionTelemetry = true,
         };
+        
         appBuilder.Logging.AddProvider(
             new ApplicationInsightsLoggerProvider(
                 Options.Create(telemetryConfig), Options.Create(logConfig)));
@@ -151,10 +155,11 @@ public static class MauiAppBuilderExtensions
     {
         var telemetryConfig = new TelemetryConfiguration()
         {
-            ConnectionString = configuration.ApplicationInsightsConnectionString
+            ConnectionString = configuration.ApplicationInsightsConnectionString,
         };
         telemetryConfig.TelemetryInitializers.Add(new AdditionalPropertiesInitializer(configuration.AdditionalTelemetryProperties));
         telemetryConfig.TelemetryInitializers.Add(new ApplicationInfoInitializer());
+        telemetryConfig.TelemetryInitializers.Add(new SessionInfoInitializer(_sessionId));
         
         foreach(var initializer in configuration.TelemetryInitializers)
         {
@@ -183,7 +188,11 @@ public static class MauiAppBuilderExtensions
             var factory = factoryMethod(serviceProvider);
             telemetryConfig.TelemetryProcessorChainBuilder.Use(factory.Create);
         }
-
         return telemetryConfig;
     }
 }
+
+public record SessionId
+{
+    public string Value { get; } = Guid.NewGuid().ToString();
+};

--- a/src/MauiInsights/SessionInfoInitializer.cs
+++ b/src/MauiInsights/SessionInfoInitializer.cs
@@ -1,0 +1,24 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace MauiInsights;
+
+internal class SessionInfoInitializer : ITelemetryInitializer
+{
+    private readonly string? _sessionId;
+
+    public SessionInfoInitializer(SessionId? sessionId)
+    {
+        _sessionId = sessionId?.Value;
+    }
+    public void Initialize(ITelemetry telemetry)
+    {
+        if (telemetry is ExceptionTelemetry) return;
+        if (string.IsNullOrEmpty(telemetry.Context.Session.Id))
+        {
+            telemetry.Context.Session.Id = _sessionId;
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to improve crash logging and session tracking in the `MauiInsights` project. The most important changes include introducing session tracking, updating the crash logger to use the new session tracking, and adding a telemetry initializer for session information.

### Session Tracking Enhancements:
* [`src/MauiInsights/MauiAppBuilderExtensions.cs`](diffhunk://#diff-e800344aa576215c6b9924c776f87976c30915125b7819940433cf56169227adL26-R28): Added a `SessionId` class to generate and store session IDs, and updated the `AddApplicationInsights` method to initialize and register the session ID. [[1]](diffhunk://#diff-e800344aa576215c6b9924c776f87976c30915125b7819940433cf56169227adL26-R28) [[2]](diffhunk://#diff-e800344aa576215c6b9924c776f87976c30915125b7819940433cf56169227adL186-R198)
* [`src/MauiInsights/SessionInfoInitializer.cs`](diffhunk://#diff-916fccf3da91e1da97cf73c97b5c1712a94e25dd0ca12201c0d9a5adc3bfdd28R1-R24): Implemented a new `SessionInfoInitializer` class to add session IDs to telemetry data.

### Crash Logger Updates:
* [`src/MauiInsights/CrashHandling/CrashLogger.cs`](diffhunk://#diff-f55033b1913959506450f11afcda937f8b672c562cad017bd2bbb00d65c6101dR3-R18): Updated the `CrashLogger` constructor to accept a `CrashLogSettings` object and a `TelemetryClient`, and modified methods to include session IDs in crash logs. [[1]](diffhunk://#diff-f55033b1913959506450f11afcda937f8b672c562cad017bd2bbb00d65c6101dR3-R18) [[2]](diffhunk://#diff-f55033b1913959506450f11afcda937f8b672c562cad017bd2bbb00d65c6101dL29-R44) [[3]](diffhunk://#diff-f55033b1913959506450f11afcda937f8b672c562cad017bd2bbb00d65c6101dL58-R70)
* [`src/MauiInsights/CrashHandling/ExceptionInfo.cs`](diffhunk://#diff-f2c963ac6bcbfaa31cb536150f327957b685aefd9ab69574ddc7e61d024754dbL5-R5): Added a `sessionId` field to the `ExceptionInfo` record to store session IDs in crash logs.

### Telemetry Enhancements:
* [`src/MauiInsights/DependencyTrackingHandler.cs`](diffhunk://#diff-852439d07c38bfbc820afe72712f2da11cea6ed0be7a59dc4420485ec94e7941L34-R41): Modified the `GetTelemetry` method to include session IDs in dependency telemetry.
* [`src/MauiInsights/MauiAppBuilderExtensions.cs`](diffhunk://#diff-e800344aa576215c6b9924c776f87976c30915125b7819940433cf56169227adR119): Updated the telemetry configuration to use the new `SessionInfoInitializer` and set the session ID for the `TelemetryClient`. [[1]](diffhunk://#diff-e800344aa576215c6b9924c776f87976c30915125b7819940433cf56169227adR119) [[2]](diffhunk://#diff-e800344aa576215c6b9924c776f87976c30915125b7819940433cf56169227adL154-R162)