### PR TITLE
Change dependency success criteria and result code format

### DIFF
--- a/src/MauiInsights/DependencyTrackingHandler.cs
+++ b/src/MauiInsights/DependencyTrackingHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.ApplicationInsights;
+﻿using System.Globalization;
+using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.Http;
 
@@ -44,8 +45,9 @@ namespace MauiInsights
 
         private void Enrich(DependencyTelemetry telemetry, HttpResponseMessage? response)
         {
-            telemetry.Success = response != null;
-            telemetry.ResultCode = response?.StatusCode.ToString();
+            int statusCode = Convert.ToInt32(response?.StatusCode);
+            telemetry.Success = (statusCode > 0) && (statusCode < 400);
+            telemetry.ResultCode = statusCode > 0 ? statusCode.ToString(CultureInfo.InvariantCulture) : string.Empty;
         }
 
         private void SetOpenTelemetryHeaders(HttpRequestMessage request, DependencyTelemetry telemetry)


### PR DESCRIPTION
This PR makes 2 changes that bring the dependency tracking more in line with how HttpClient requests are tracked in an aspnet core application.

### Telemetry Enhancements:
 * [`src/MauiInsights/DependencyTrackingHandler.cs`](https://github.com/sswart/MauiInsights/blob/eec4130eb464b8e6f52768606e910d48a2fb4315/src/MauiInsights/DependencyTrackingHandler.cs#L48-L50): Modified the `Enrich` method to match [how Microsoft determines](https://github.com/microsoft/ApplicationInsights-dotnet/blob/18ffbf6427ee705179052bfc94356c593621db85/WEB/Src/DependencyCollector/DependencyCollector/Implementation/HttpProcessing.cs#L418) `Success` and `ResultCode`.
 
 ### Motivation:
* Error responses (such as gateway timeouts, internal server errors, etc) are currently being tracked as Success = True just because the http client received a response
* ResultCode searching/filtering/grouping is challenging when using Enum.ToString(), which gives us "OK", "GatewayTimeout", "InternalServerError", etc instead of 200, 504, 500, etc.