### PR TITLE
Add support for Request-Id legacy correlation header

### DIFF
--- a/src/MauiInsights/DependencyTrackingHandler.cs
+++ b/src/MauiInsights/DependencyTrackingHandler.cs
@@ -57,7 +57,7 @@ namespace MauiInsights
             var parentId = telemetry.Context.Operation.Id;
             var traceId = telemetry.Id;
             
-            if (_configuration.UseOpenTelemetryHeaders)
+            if (_configuration.EnableW3CCorrelation)
             {
                 var version = "00";
                 var flags = _client.Context.Flags;

--- a/src/MauiInsights/MauiAppBuilderExtensions.cs
+++ b/src/MauiInsights/MauiAppBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class MauiAppBuilderExtensions
         _sessionId = new SessionId();
         appBuilder.Services.AddSingleton(_sessionId);
         SetupTelemetryClient(appBuilder, configuration, configureTelemetry);
-        SetupHttpDependecyTracking(appBuilder);
+        SetupHttpDependecyTracking(appBuilder, configuration);
         SetupPageViewTelemetry();
         SetupLogger(appBuilder, configuration);
         SetupTelemetryLifecycleEvents(appBuilder);
@@ -120,9 +120,9 @@ public static class MauiAppBuilderExtensions
         appBuilder.Services.AddSingleton(_client);
     }
 
-    private static void SetupHttpDependecyTracking(MauiAppBuilder appBuilder)
+    private static void SetupHttpDependecyTracking(MauiAppBuilder appBuilder, MauiInsightsConfiguration configuration)
     {
-        appBuilder.Services.AddTransient<DependencyTrackingHandler>();
+        appBuilder.Services.AddTransient(provider => new DependencyTrackingHandler(provider.GetRequiredService<TelemetryClient>(), configuration));
         appBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IHttpMessageHandlerBuilderFilter, DependencyTrackingHandlerFilter>());
     }
 

--- a/src/MauiInsights/MauiInsightsConfiguration.cs
+++ b/src/MauiInsights/MauiInsightsConfiguration.cs
@@ -5,7 +5,7 @@ namespace MauiInsights;
 public class MauiInsightsConfiguration
 {
     public string? ApplicationInsightsConnectionString { get; set; }
-    public bool UseOpenTelemetryHeaders { get; set; } = true;
+    public bool EnableW3CCorrelation { get; set; } = true;
     public IDictionary<string, string> AdditionalTelemetryProperties { get; set; } = new Dictionary<string, string>();
     [Obsolete("Use the AddApplicationInsights with the configureTelemetry parameter instead to add ITelemetryInitializers")]
     public IEnumerable<ITelemetryInitializer> TelemetryInitializers { get; set; } = Enumerable.Empty<ITelemetryInitializer>();

--- a/src/MauiInsights/MauiInsightsConfiguration.cs
+++ b/src/MauiInsights/MauiInsightsConfiguration.cs
@@ -5,6 +5,7 @@ namespace MauiInsights;
 public class MauiInsightsConfiguration
 {
     public string? ApplicationInsightsConnectionString { get; set; }
+    public bool UseOpenTelemetryHeaders { get; set; } = true;
     public IDictionary<string, string> AdditionalTelemetryProperties { get; set; } = new Dictionary<string, string>();
     [Obsolete("Use the AddApplicationInsights with the configureTelemetry parameter instead to add ITelemetryInitializers")]
     public IEnumerable<ITelemetryInitializer> TelemetryInitializers { get; set; } = Enumerable.Empty<ITelemetryInitializer>();


### PR DESCRIPTION
This pull request adds a new option `UseOpenTelemetryHeaders` to the `MauiInsightsConfiguration` class. It defaults to `true`, which is current functionality. When set to `false`, instead of adding a `traceparent` header to all HTTP requests, a `Request-Id` header is added instead.

### Telemetry Enhancements:
 * [`src/MauiInsights/MauiInsightsConfiguration.cs`](https://github.com/sswart/MauiInsights/blob/29d57a2b35f924059eda1722fb0e7eef554d7212/src/MauiInsights/MauiInsightsConfiguration.cs#L8): Added new configuration property `UseOpenTelemetryHeaders` (default is `true` for current functionality)
 * [`src/MauiInsights/MauiAppBuilderExtensions.cs`](https://github.com/sswart/MauiInsights/blob/29d57a2b35f924059eda1722fb0e7eef554d7212/src/MauiInsights/MauiAppBuilderExtensions.cs#L125): Updated the service setup to pass configuration to the `DependencyTrackingHandler`
 * [`src/MauiInsights/DependencyTrackingHandler.cs`](https://github.com/sswart/MauiInsights/blob/29d57a2b35f924059eda1722fb0e7eef554d7212/src/MauiInsights/DependencyTrackingHandler.cs#L58-L67): Updated the `DependencyTrackingHandler` to use the new setting to determine which correlation header to use: `traceparent` or `Request-Id`

### Motivation:
The purpose of this change is to allow telemetry correlation across systems that do not support the `traceparent` request header and instead expect a `Request-Id` header. Far more details than I fully understand can be found [here](https://github.com/microsoft/ApplicationInsights-dotnet/blob/18ffbf6427ee705179052bfc94356c593621db85/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs#L194-L206). All I know is that this change was required to get our telemetry to correlate with an ASP.NET Core 8 API.